### PR TITLE
Allow for fully typed helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # vuex-composition-helpers
+
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/greenpress/vuex-composition-helpers%2Ftest?type=cf-1)]( https%3A%2F%2Fg.codefresh.io%2Fpipelines%2Ftest%2Fbuilds%3Ffilter%3Dtrigger%3Abuild~Build%3Bpipeline%3A5e915b7d4c3d6b0fd35ac83d~test)
 
 A util package to use Vuex with Composition API easily.
 
 ## Installation
-```
+
+```shell
 $ npm install vuex-composition-helpers
 ```
 
-
-###  Basic Usage Examples
+### Basic Usage Examples
 
 ```js
 import { useState, useActions } from 'vuex-composition-helpers';
@@ -32,9 +33,7 @@ export default {
 }
 ```
 
-
-
-###  Namespaced Usage Examples
+### Namespaced Usage Examples
 
 ```js
 import { createNamespacedHelpers } from 'vuex-composition-helpers';
@@ -57,7 +56,6 @@ export default {
 	}
 }
 ```
-
 
 You can also import your store from outside the component, and create the helpers outside of the `setup` method, for example:
 
@@ -84,7 +82,42 @@ export default {
 }
 ```
 
+### Typescript mappings
+
+You can also supply typing information to each of the mapping functions to provide a fully typed mapping.
+
+```ts
+import { useState, useActions } from 'vuex-composition-helpers';
+
+interface RootGetters extends GetterTree<any, any> {
+	article: string;
+	comments: string;
+}
+
+interface RootActions extends ActionTree<any, any> {
+	fetch: (ctx: ActionContext<any, any>, payload: number);
+}
+
+export default {
+	props: {
+		articleId: String
+	},
+	setup(props) {
+		const { fetch } = useActions<RootActions>(['fetch']);
+		const { article, comments } = useGetters<RootGetters>(['article', 'comments']);
+		fetch(props.articleId); // dispatch the "fetch" action
+
+		return {
+			// both are computed compositions for to the store
+			article,
+			comments
+		}
+	}
+}
+```
+
 ### Advanced Usage Example
+
 consider separate the store composition file from the store usage inside the component. i.g.:
 
 ```js
@@ -94,7 +127,6 @@ import store from '@/store'; // local store file
 
 export default wrapStore(store);
 ```
-
 
 ```js
 // my-component.vue:
@@ -118,6 +150,5 @@ export default {
 	}
 }
 ```
-
 
 Enjoy!

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,6 +1,6 @@
 import {Store} from 'vuex/types';
 import {computed} from '@vue/composition-api';
-import {computedGetter, getAction, getMutation, getStoreFromInstance, Mapper, MapArgument, useMapping, ExtractGetterTypes, ExtractTypes, KnownKeys, RefTypes} from './util';
+import {computedGetter, getAction, getMutation, getStoreFromInstance, useMapping, ExtractGetterTypes, ExtractTypes, KnownKeys, RefTypes} from './util';
 
 function computedState(store: any, prop: string) {
 	return computed(() => store.state[prop]);

--- a/src/global.ts
+++ b/src/global.ts
@@ -1,46 +1,46 @@
 import {Store} from 'vuex/types';
 import {computed} from '@vue/composition-api';
-import {computedGetter, getAction, getMutation, getStoreFromInstance, Mapper, MapArgument, useMapping} from './util';
+import {computedGetter, getAction, getMutation, getStoreFromInstance, Mapper, MapArgument, useMapping, ExtractGetterTypes, ExtractTypes, KnownKeys, RefTypes} from './util';
 
 function computedState(store: any, prop: string) {
 	return computed(() => store.state[prop]);
 }
 
-export function useState<T = any>(storeOrMap: Store<T> | MapArgument, map?: MapArgument): Mapper<any> {
+export function useState<TState = any>(storeOrMap: Store<TState> | KnownKeys<TState>[], map?: KnownKeys<TState>[]): RefTypes<TState> {
 	let store = storeOrMap;
 
 	if (arguments.length === 1) {
-		map = store as MapArgument;
-		store = getStoreFromInstance<T>();
+		map = store as KnownKeys<TState>[];
+		store = getStoreFromInstance();
 	}
 	return useMapping(store, null, map, computedState);
 }
 
-export function useGetters<T = any>(storeOrMap: Store<T> | MapArgument, map?: MapArgument): Mapper<any> {
+export function useGetters<TGetters = any>(storeOrMap: Store<any> | KnownKeys<TGetters>[], map?: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters> {
 	let store = storeOrMap;
 	if (arguments.length === 1) {
-		map = store as MapArgument;
-		store = getStoreFromInstance<T>();
+		map = store as KnownKeys<TGetters>[];
+		store = getStoreFromInstance();
 	}
 	return useMapping(store, null, map, computedGetter);
 }
 
-export function useMutations<T = any>(storeOrMap: Store<T> | MapArgument, map?: MapArgument): Mapper<Function> {
+export function useMutations<TMutations = any>(storeOrMap: Store<any> | KnownKeys<TMutations>[], map?: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function> {
 	let store = storeOrMap;
 
 	if (arguments.length === 1) {
-		map = store as MapArgument;
-		store = getStoreFromInstance<T>();
+		map = store as KnownKeys<TMutations>[];
+		store = getStoreFromInstance();
 	}
 	return useMapping(store, null, map, getMutation);
 }
 
-export function useActions<T = any>(storeOrMap: Store<T> | MapArgument, map?: MapArgument): Mapper<Function> {
+export function useActions<TActions = any>(storeOrMap: Store<any> | KnownKeys<TActions>[], map?: KnownKeys<TActions>[]): ExtractTypes<TActions, Function> {
 	let store = storeOrMap;
 
 	if (arguments.length === 1) {
-		map = store as MapArgument;
-		store = getStoreFromInstance<T>();
+		map = store as KnownKeys<TActions>[];
+		store = getStoreFromInstance();
 	}
 	return useMapping(store, null, map, getAction);
 }

--- a/src/namespaced.ts
+++ b/src/namespaced.ts
@@ -64,7 +64,7 @@ export function useNamespacedGetters<TGetters = any>(storeOrNamespace: Store<any
 	return useMapping(store, namespace, map, computedGetter);
 }
 
-export function createNamespacedHelpers<TState = any, TMutations = any, TActions = any, TGetters = any>(storeOrNamespace: Store<any> | string, namespace?: string):{
+export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(storeOrNamespace: Store<any> | string, namespace?: string):{
 	useState: (map?: KnownKeys<TState>[]) => RefTypes<TState>;
 	useGetters: (map?: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
 	useMutations: (map?: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;

--- a/src/namespaced.ts
+++ b/src/namespaced.ts
@@ -1,5 +1,5 @@
 import {computed} from '@vue/composition-api';
-import {computedGetter, getAction, getMutation, getStoreFromInstance, MapArgument, Mapper, useMapping} from './util';
+import {computedGetter, getAction, getMutation, getStoreFromInstance, MapArgument, Mapper, useMapping, KnownKeys, RefTypes, ExtractTypes, ExtractGetterTypes} from './util';
 import {Store} from 'vuex';
 
 export type Nullish = null | undefined;
@@ -8,76 +8,81 @@ function computedState(store: any, namespace: string, prop: string) {
 	return computed(() => store.state[namespace][prop])
 }
 
-export function useNamespacedState<T = any>(storeOrNamespace: Store<T> | string | Nullish, namespaceOrMap: string | MapArgument, map?: MapArgument): Mapper<any> {
-	let store: Store<T>, namespace: string;
+export function useNamespacedState<TState = any>(storeOrNamespace: Store<any> | string  | Nullish, namespaceOrMap: string | KnownKeys<TState>[], map?: KnownKeys<TState>[]): RefTypes<TState> {
+	let store: Store<any>, namespace: string;
 
 	if (arguments.length === 2) {
-		store = getStoreFromInstance<T>();
-		map = namespaceOrMap as MapArgument;
+		store = getStoreFromInstance();
+		map = namespaceOrMap as KnownKeys<TState>[];
 		namespace = storeOrNamespace as string;
 	} else {
-		store = storeOrNamespace as Store<T> || getStoreFromInstance<T>();
+		store = storeOrNamespace as Store<TState> || getStoreFromInstance();
 		namespace = namespaceOrMap as string;
 	}
 	return useMapping(store, namespace, map, computedState);
 }
 
-export function useNamespacedMutations<T = any>(storeOrNamespace: Store<T> | string | Nullish, namespaceOrMap: string | MapArgument, map?: MapArgument): Mapper<Function> {
-	let store: Store<T>, namespace: string;
+export function useNamespacedMutations<TMutations = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TMutations>[], map?: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function> {
+	let store: Store<any>, namespace: string;
 
 	if (arguments.length === 2) {
-		store = getStoreFromInstance<T>();
-		map = namespaceOrMap as MapArgument;
+		store = getStoreFromInstance();
+		map = namespaceOrMap as KnownKeys<TMutations>[];
 		namespace = storeOrNamespace as string;
 	} else {
-		store = storeOrNamespace as Store<T> || getStoreFromInstance<T>();
+		store = storeOrNamespace as Store<any> || getStoreFromInstance();
 		namespace = namespaceOrMap as string;
 	}
 	return useMapping(store, namespace, map, getMutation);
 }
 
-export function useNamespacedActions<T = any>(storeOrNamespace: Store<T> | string | Nullish, namespaceOrMap: string | MapArgument, map?: MapArgument): Mapper<Function> {
-	let store: Store<T>, namespace: string;
+export function useNamespacedActions<TActions = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TActions>[], map?: KnownKeys<TActions>[]): ExtractTypes<TActions, Function> {
+	let store: Store<any>, namespace: string;
 
 	if (arguments.length === 2) {
-		store = getStoreFromInstance<T>();
-		map = namespaceOrMap as MapArgument;
+		store = getStoreFromInstance();
+		map = namespaceOrMap as KnownKeys<TActions>[];
 		namespace = storeOrNamespace as string;
 	} else {
-		store = storeOrNamespace as Store<T> || getStoreFromInstance<T>();
+		store = storeOrNamespace as Store<any> || getStoreFromInstance();
 		namespace = namespaceOrMap as string;
 	}
 	return useMapping(store, namespace, map, getAction);
 }
 
-export function useNamespacedGetters<T = any>(storeOrNamespace: Store<T> | string | Nullish, namespaceOrMap: string | MapArgument, map?: MapArgument): Mapper<any> {
-	let store: Store<T>, namespace: string;
+export function useNamespacedGetters<TGetters = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TGetters>[], map?: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters> {
+	let store: Store<any>, namespace: string;
 
 	if (arguments.length === 2) {
-		store = getStoreFromInstance<T>();
-		map = namespaceOrMap as MapArgument;
+		store = getStoreFromInstance();
+		map = namespaceOrMap as KnownKeys<TGetters>[];
 		namespace = storeOrNamespace as string;
 	} else {
-		store = storeOrNamespace as Store<T> || getStoreFromInstance<T>();
+		store = storeOrNamespace as Store<any> || getStoreFromInstance();
 		namespace = namespaceOrMap as string;
 	}
 	return useMapping(store, namespace, map, computedGetter);
 }
 
-export function createNamespacedHelpers<T = any>(storeOrNamespace: Store<T> | string, namespace?: string) {
-	let store: Store<T> | Nullish = undefined;
+export function createNamespacedHelpers<TState = any, TMutations = any, TActions = any, TGetters = any>(storeOrNamespace: Store<any> | string, namespace?: string):{
+	useState: (map?: KnownKeys<TState>[]) => RefTypes<TState>;
+	useGetters: (map?: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
+	useMutations: (map?: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
+	useActions: (map?: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
+} {
+	let store: Store<any> | Nullish = undefined;
 	if (arguments.length === 1) {
 		namespace = storeOrNamespace as string;
 	} else {
-		store = storeOrNamespace as Store<T>;
+		store = storeOrNamespace as Store<any>;
 		if (!namespace) {
 			throw new Error('Namespace is missing to provide namespaced helpers')
 		}
 	}
 	return {
-		useState: useNamespacedState.bind(null, store, namespace),
-		useMutations: useNamespacedMutations.bind(null, store, namespace),
-		useActions: useNamespacedActions.bind(null, store, namespace),
-		useGetters: useNamespacedGetters.bind(null, store, namespace),
+		useState: (map?: KnownKeys<TState>[]) => useNamespacedState(store, namespace as string, map),
+		useGetters: (map?: KnownKeys<TGetters>[]) => useNamespacedGetters(store, namespace as string, map),
+		useMutations: (map?: KnownKeys<TMutations>[]) => useNamespacedMutations(store, namespace as string, map),
+		useActions: (map?: KnownKeys<TActions>[]) => useNamespacedActions(store, namespace as string, map),
 	}
 }

--- a/src/namespaced.ts
+++ b/src/namespaced.ts
@@ -1,5 +1,5 @@
 import {computed} from '@vue/composition-api';
-import {computedGetter, getAction, getMutation, getStoreFromInstance, MapArgument, Mapper, useMapping, KnownKeys, RefTypes, ExtractTypes, ExtractGetterTypes} from './util';
+import {computedGetter, getAction, getMutation, getStoreFromInstance, useMapping, KnownKeys, RefTypes, ExtractTypes, ExtractGetterTypes} from './util';
 import {Store} from 'vuex';
 
 export type Nullish = null | undefined;

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,13 +41,6 @@ export declare type RefTypes<T> = {
 	readonly [Key in keyof T]: Ref<T[Key]>
 }
 
-
-export interface Mapper<T = string> {
-	[key: string]: T
-}
-
-export type MapArgument = Mapper | Array<string>;
-
 function runCB<T>(cb: Function, store: any, namespace: string | null, prop: KnownKeys<T> | string) {
 	if (cb.length === 3) { // choose which signature to pass to cb function
 		return cb(store, namespace, prop);

--- a/tests/global-actions.test.ts
+++ b/tests/global-actions.test.ts
@@ -82,6 +82,47 @@ describe('"useActions" - global store actions helpers', () => {
 			expect(dispatcher).toBeCalledTimes(1);
 			expect(dispatcher).toBeCalledWith(store.state, clickValue);
 		});
+
+		it('should dispatch a typed action with given payload', () => {
+			const clickValue = 'demo-click-' + Math.random();
+			const dispatcher = jest.fn();
+
+			interface Actions {
+				doTest: (ctx: any, payload: string) => void
+			}
+
+			const store = new Vuex.Store({
+				state: {
+					val: 'test-demo' + Math.random()
+				},
+				actions: {
+					doTest: ({state}, payload) => {
+						dispatcher(state, payload);
+					}
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div @click="onClicked">click</div>',
+					setup() {
+						const {doTest} = useActions<Actions>(['doTest']);
+						const onClicked = () => doTest(clickValue);
+						return {
+							onClicked,
+							doTest
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(dispatcher).not.toBeCalled();
+
+			wrapper.find('div').trigger('click');
+
+			expect(dispatcher).toBeCalledTimes(1);
+			expect(dispatcher).toBeCalledWith(store.state, clickValue);
+		});
 	})
 
 });

--- a/tests/global-getters.test.ts
+++ b/tests/global-getters.test.ts
@@ -37,6 +37,33 @@ describe('"useGetters" - global store getters helpers', () => {
 			expect(wrapper.text()).toBe(store.getters['valGetter']);
 		});
 
+		it('should render component using a typed state getter', () => {
+			interface Getters {
+				valGetter: (state: any) => String;
+			};
+
+			const value = 'getter-demo' + Math.random();
+			const store = new Vuex.Store({
+				getters: {
+					valGetter: (state) => value
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div>{{valGetter}}</div>',
+					setup() {
+						const {valGetter} = useGetters<Getters>(store, ['valGetter']);
+						return {
+							valGetter
+						}
+					}
+				},
+				{localVue}
+			);
+
+			expect(wrapper.text()).toBe(store.getters['valGetter']);
+		});
+
 		it('should change component contents according a getter change', async () => {
 			const store = new Vuex.Store({
 				state: {
@@ -89,6 +116,48 @@ describe('"useGetters" - global store getters helpers', () => {
 					template: '<div>{{val}}</div>',
 					setup() {
 						const {testGetter} = useGetters(store, ['testGetter']);
+
+						watch(testGetter, watcher);
+
+						return {
+							val: testGetter
+						}
+					}
+				},
+				{localVue}
+			);
+			expect(watcher).toBeCalledTimes(1);
+
+
+			store.state.val = 'new value' + Math.random();
+
+			expect(watcher).toBeCalledTimes(1);
+
+			// wait for rendering
+			await wrapper.vm.$nextTick();
+
+			expect(watcher).toBeCalledTimes(2);
+		});
+
+		it('should trigger a watcher according a typed getter change', async () => {
+			const watcher = jest.fn();
+			interface Getters {
+				testGetter: (state: any) => String;
+			};
+
+			const store = new Vuex.Store({
+				state: {
+					val: 'test-demo' + Math.random()
+				},
+				getters: {
+					testGetter: (state) => state.val
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div>{{val}}</div>',
+					setup() {
+						const {testGetter} = useGetters<Getters>(store, ['testGetter']);
 
 						watch(testGetter, watcher);
 

--- a/tests/global-mutations.test.ts
+++ b/tests/global-mutations.test.ts
@@ -86,6 +86,50 @@ describe('"useMutations" - global store mutations helpers', () => {
 			expect(mutate).toBeCalledWith(clickValue);
 			expect(store.state.val).toBe(clickValue);
 		});
+
+		it('should commit a typed mutation with given payload', () => {
+			const clickValue = 'demo-click-' + Math.random();
+			const mutate = jest.fn();
+
+			interface Mutations {
+				change: (state: any, payload: string) => void;
+			}
+
+			const store = new Vuex.Store({
+				state: {
+					val: 'test-demo' + Math.random()
+				},
+				mutations: {
+					change: (state, payload) => {
+						state.val = payload;
+						mutate(payload);
+					}
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: `<div @click="onClicked">click</div>`,
+					setup() {
+						const {change} = useMutations<Mutations>(['change']);
+						const onClicked = () => change(clickValue);
+
+						return {
+							onClicked,
+							change
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(mutate).not.toBeCalled();
+
+			wrapper.find('div').trigger('click');
+
+			expect(mutate).toBeCalledTimes(1);
+			expect(mutate).toBeCalledWith(clickValue);
+			expect(store.state.val).toBe(clickValue);
+		});
 	})
 
 });

--- a/tests/global-state.test.ts
+++ b/tests/global-state.test.ts
@@ -36,6 +36,33 @@ describe('"useState" - global store state helpers', () => {
 			expect(wrapper.text()).toBe(store.state.val);
 		});
 
+		it('should render component using a typed state value', () => {
+			interface RootState {
+				val: string;
+				num: number;
+			};
+			const store = new Vuex.Store<RootState>({
+				state: {
+					val: 'test-demo' + Math.random(),
+					num: 3
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div>{{stateVal}}</div>',
+					setup() {
+						const {val} = useState<RootState>(store, ['val']);
+						return {
+							stateVal: val
+						}
+					}
+				},
+				{localVue}
+			);
+
+			expect(wrapper.text()).toBe(store.state.val);
+		});
+
 		it('should change component contents according a state change', async () => {
 			const store = new Vuex.Store({
 				state: {
@@ -118,6 +145,31 @@ describe('"useState" - global store state helpers', () => {
 					template: '<div>{{stateVal}}</div>',
 					setup() {
 						const {val} = useState(['val']);
+						return {
+							stateVal: val
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(wrapper.text()).toBe(store.state.val);
+		});
+
+		it('should render component using a typed state value', () => {
+			interface RootState {
+				val: string,
+			};
+			const store = new Vuex.Store({
+				state: {
+					val: 'test-demo' + Math.random()
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div>{{stateVal}}</div>',
+					setup() {
+						const {val} = useState<RootState>(['val']);
 						return {
 							stateVal: val
 						}

--- a/tests/namespaced-actions.test.ts
+++ b/tests/namespaced-actions.test.ts
@@ -139,6 +139,54 @@ describe('"useNamespacedActions" - namespaced store actions helpers', () => {
 			expect(dispatcher).toBeCalledTimes(1);
 			expect(dispatcher).toBeCalledWith(storeModule.state, clickValue);
 		});
+
+		it('should dispatch a typed action with given payload', () => {
+			const clickValue = 'demo-click-' + Math.random();
+			const dispatcher = jest.fn();
+
+			interface Actions {
+				doTest: (ctx: any, payload: string) => void
+			}
+
+			const storeModule: Module<any, any> = {
+				namespaced: true,
+				state: {
+					val: 'test-demo' + Math.random()
+				},
+				actions: {
+					doTest: ({state}, payload) => {
+						dispatcher(state, payload);
+					}
+				}
+			};
+			const store = new Vuex.Store({
+				state: {},
+				modules: {
+					foo: storeModule
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div @click="onClicked">click</div>',
+					setup() {
+						const {doTest} = useNamespacedActions<Actions>('foo', ['doTest']);
+						const onClicked = () => doTest(clickValue);
+						return {
+							onClicked,
+							doTest
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(dispatcher).not.toBeCalled();
+
+			wrapper.find('div').trigger('click');
+
+			expect(dispatcher).toBeCalledTimes(1);
+			expect(dispatcher).toBeCalledWith(storeModule.state, clickValue);
+		});
 	});
 
 });

--- a/tests/namespaced-mutations.test.ts
+++ b/tests/namespaced-mutations.test.ts
@@ -142,6 +142,53 @@ describe('"useNamespacedMutations" - namespaced store mutations helpers', () => 
 			expect(mutate).toBeCalledTimes(1);
 			expect(mutate).toBeCalledWith(clickValue);
 		});
+
+		it('should dispatch action with given payload', () => {
+			const clickValue = 'demo-click-' + Math.random();
+			const mutate = jest.fn();
+			interface Mutations {
+				doTest: (state: any, payload: string) => void;
+			}
+			const storeModule: Module<any, any> = {
+				namespaced: true,
+				state: {
+					val: 'test-demo' + Math.random()
+				},
+				mutations: {
+					doTest: (state, payload) => {
+						state.val = payload;
+						mutate(payload);
+					}
+				}
+			};
+			const store = new Vuex.Store({
+				state: {},
+				modules: {
+					foo: storeModule
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: `<div @click="onClicked">click</div>`,
+					setup() {
+						const {doTest} = useNamespacedMutations<Mutations>('foo', ['doTest']);
+						const onClicked = () => doTest(clickValue);
+						return {
+							onClicked,
+							doTest
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(mutate).not.toBeCalled();
+
+			wrapper.find('div').trigger('click');
+
+			expect(mutate).toBeCalledTimes(1);
+			expect(mutate).toBeCalledWith(clickValue);
+		});
 	});
 
 });

--- a/tests/namespaced-state.test.ts
+++ b/tests/namespaced-state.test.ts
@@ -41,7 +41,38 @@ describe('"useNamespacedState" - namespaced store state helpers', () => {
 
 			expect(wrapper.text()).toBe(storeModule.state.val);
 		});
+		
+		it('should render component using a typed state value', () => {
+			interface ModuleState {
+				val: string
+			};
+			const storeModule: Module<any, any> = {
+				namespaced: true,
+				state: {
+					val: 'test-demo' + Math.random()
+				}
+			};
+			const store = new Vuex.Store({
+				modules: {
+					foo: storeModule
+				}
+			});
 
+			const wrapper = shallowMount({
+					template: '<div>{{stateVal}}</div>',
+					setup() {
+						const {val} = useNamespacedState<ModuleState>(store, 'foo', ['val']);
+						return {
+							stateVal: val
+						}
+					}
+				},
+				{localVue}
+			);
+
+			expect(wrapper.text()).toBe(storeModule.state.val);
+		});
+		
 		it('should change component contents according a state change', async () => {
 			const storeModule: Module<any, any> = {
 				namespaced: true,
@@ -142,6 +173,36 @@ describe('"useNamespacedState" - namespaced store state helpers', () => {
 					template: '<div>{{stateVal}}</div>',
 					setup() {
 						const {val} = useNamespacedState(undefined, 'foo', ['val']);
+						return {
+							stateVal: val
+						}
+					}
+				},
+				{localVue, store}
+			);
+
+			expect(wrapper.text()).toBe(storeModule.state.val);
+		});
+		it('should render component using a typed state value', () => {
+			interface ModuleState {
+				val: string;
+			};
+			const storeModule: Module<any, any> = {
+				namespaced: true,
+				state: {
+					val: 'test-demo' + Math.random()
+				}
+			};
+			const store = new Vuex.Store({
+				modules: {
+					foo: storeModule
+				}
+			});
+
+			const wrapper = shallowMount({
+					template: '<div>{{stateVal}}</div>',
+					setup() {
+						const {val} = useNamespacedState<ModuleState>(undefined, 'foo', ['val']);
 						return {
 							stateVal: val
 						}


### PR DESCRIPTION
This adds the capability for typescript to supply interfaces to each of the methods and get a fully typed mapping back.  I've also added a test for a getter with params and an async action.

This implements issue #6 