### PR TITLE
Fix for extended interfaces

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -27,15 +27,15 @@ export declare type ExtractGetterTypes<O> = {
 
 export declare type KnownKeys<T> = {
 	[K in keyof T]: string extends K
-	? any
+	? never
 	: number extends K
-	? any
+	? never
 	: K
 } extends {
 		[_ in keyof T]: infer U
 	}
 	? U
-	: any;
+	: never;
 
 export declare type RefTypes<T> = {
 	readonly [Key in keyof T]: Ref<T[Key]>

--- a/tests/global-actions.test.ts
+++ b/tests/global-actions.test.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuex from 'vuex';
+import Vuex, { ActionTree } from 'vuex';
 import {shallowMount} from '@vue/test-utils';
 
 import {getLocalVue} from './utils/local-vue';
@@ -87,7 +87,7 @@ describe('"useActions" - global store actions helpers', () => {
 			const clickValue = 'demo-click-' + Math.random();
 			const dispatcher = jest.fn();
 
-			interface Actions {
+			interface Actions extends ActionTree<any, any> {
 				doTest: (ctx: any, payload: string) => void
 			}
 

--- a/tests/global-getters.test.ts
+++ b/tests/global-getters.test.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuex from 'vuex';
+import Vuex, { GetterTree } from 'vuex';
 import {shallowMount} from '@vue/test-utils';
 
 import {getLocalVue} from './utils/local-vue';
@@ -195,7 +195,7 @@ describe('"useGetters" - global store getters helpers', () => {
 
 		it('should trigger a watcher according a typed getter change', async () => {
 			const watcher = jest.fn();
-			interface Getters {
+			interface Getters extends GetterTree<any, any> {
 				testGetter: (state: any) => String;
 			};
 

--- a/tests/global-mutations.test.ts
+++ b/tests/global-mutations.test.ts
@@ -1,5 +1,5 @@
 import Vue from 'vue';
-import Vuex from 'vuex';
+import Vuex, { MutationTree } from 'vuex';
 import {shallowMount} from '@vue/test-utils';
 
 import {getLocalVue} from './utils/local-vue';
@@ -91,7 +91,7 @@ describe('"useMutations" - global store mutations helpers', () => {
 			const clickValue = 'demo-click-' + Math.random();
 			const mutate = jest.fn();
 
-			interface Mutations {
+			interface Mutations extends MutationTree<any> {
 				change: (state: any, payload: string) => void;
 			}
 


### PR DESCRIPTION
Small update to allow type detection of interfaces the extend `ActionTree`, `MutationTree`, and `GetterTree` interfaces.