### PR TITLE
added more documentation and types to both namespaced and global functions.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = crlf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = false

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules\\typescript\\lib"
+}

--- a/src/global.ts
+++ b/src/global.ts
@@ -6,10 +6,35 @@ function computedState(store: any, prop: string) {
 	return computed(() => store.state[prop]);
 }
 
+/**
+ * Get the vuex store from the root vue instance
+ *
+ * @example
+ * const store = useStore();
+ */
 export function useStore<TState = any>() {
 	return getStoreFromInstance() as Store<TState>
 }
 
+/**
+ * Gets the root state of the vuex store.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param map An array of known Root State keys
+ *
+ * @example
+ * const { foo, bar } = useState(['foo', 'bar']);
+ */
+export function useState<TState>(map: KnownKeys<TState>[]): RefTypes<TState>
+/**
+ * Gets the root State of the provided vuex store.
+ * @param store An instance of the vuex store to get the state from
+ * @param map An array of known Root State keys
+ *
+ * @example
+ * const { foo, bar } = useState(store, ['foo', 'bar']);
+ */
+export function useState<TState>(store: Store<TState>, map: KnownKeys<TState>[]): RefTypes<TState>
 export function useState<TState = any>(storeOrMap: Store<TState> | KnownKeys<TState>[], map?: KnownKeys<TState>[]): RefTypes<TState> {
 	let store = storeOrMap;
 
@@ -20,6 +45,25 @@ export function useState<TState = any>(storeOrMap: Store<TState> | KnownKeys<TSt
 	return useMapping(store, null, map, computedState);
 }
 
+/**
+ * Retrieves getters for the given keys.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param map An array of known Getter keys
+ *
+ * @example
+ * const { fooGetter, barGetter } = useGetters(['fooGetter', 'barGetter']);
+ */
+export function useGetters<TGetters = any>(map: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters>
+/**
+ * Retrieves getters for the provided vuex store.
+ * @param store An instance of the vuex store to retrieve the getters from
+ * @param map An array of known Getter keys
+ *
+ * @example
+ * const { fooGetter, barGetter } = useGetters(store, ['fooGetter', 'barGetter']);
+ */
+export function useGetters<TGetters = any>(store: Store<any>, map: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters>
 export function useGetters<TGetters = any>(storeOrMap: Store<any> | KnownKeys<TGetters>[], map?: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters> {
 	let store = storeOrMap;
 	if (arguments.length === 1) {
@@ -29,6 +73,25 @@ export function useGetters<TGetters = any>(storeOrMap: Store<any> | KnownKeys<TG
 	return useMapping(store, null, map, computedGetter);
 }
 
+/**
+ * Retrieves mutations for the given keys.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param map An array of known mutation keys
+ *
+ * @example
+ * const { setFoo, setBar } = useMutations(['setFoo', 'setBar']);
+ */
+export function useMutations<TMutations = any>(map: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function>
+/**
+ * Retrieves mutations from the provided vuex store.
+ * @param store An instance of the vuex store to retrieve the mutations from
+ * @param map An array of known mutation keys
+ *
+ * @example
+ * const { setFoo, setBar } = useMutations(store, ['setFoo', 'setBar']);
+ */
+export function useMutations<TMutations = any>(store: Store<any>, map: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function>
 export function useMutations<TMutations = any>(storeOrMap: Store<any> | KnownKeys<TMutations>[], map?: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function> {
 	let store = storeOrMap;
 
@@ -39,6 +102,25 @@ export function useMutations<TMutations = any>(storeOrMap: Store<any> | KnownKey
 	return useMapping(store, null, map, getMutation);
 }
 
+/**
+ * Retrieves actions for the given keys.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param map An array of known action keys
+ *
+ * @example
+ * const { doFoo, doBar } = useActions(['doFoo', 'doBar']);
+ */
+export function useActions<TActions = any>(map: KnownKeys<TActions>[]): ExtractTypes<TActions, Function>
+/**
+ * Retrieves actions from the provided vuex store.
+ * @param store An instance of the vuex store to retrieve the actions from
+ * @param map An array of known action keys
+ *
+ * @example
+ * const { doFoo, doBar } = useActions(store, ['doFoo', 'doBar']);
+ */
+export function useActions<TActions = any>(store: Store<any>, map: KnownKeys<TActions>[]): ExtractTypes<TActions, Function>
 export function useActions<TActions = any>(storeOrMap: Store<any> | KnownKeys<TActions>[], map?: KnownKeys<TActions>[]): ExtractTypes<TActions, Function> {
 	let store = storeOrMap;
 

--- a/src/global.ts
+++ b/src/global.ts
@@ -42,7 +42,7 @@ export function useState<TState = any>(storeOrMap: Store<TState> | KnownKeys<TSt
 		map = store as KnownKeys<TState>[];
 		store = getStoreFromInstance();
 	}
-	return useMapping(store, null, map, computedState);
+	return useMapping(store as Store<TState>, null, map, computedState);
 }
 
 /**
@@ -70,7 +70,7 @@ export function useGetters<TGetters = any>(storeOrMap: Store<any> | KnownKeys<TG
 		map = store as KnownKeys<TGetters>[];
 		store = getStoreFromInstance();
 	}
-	return useMapping(store, null, map, computedGetter);
+	return useMapping(store as Store<any>, null, map, computedGetter);
 }
 
 /**
@@ -99,7 +99,7 @@ export function useMutations<TMutations = any>(storeOrMap: Store<any> | KnownKey
 		map = store as KnownKeys<TMutations>[];
 		store = getStoreFromInstance();
 	}
-	return useMapping(store, null, map, getMutation);
+	return useMapping(store as Store<any>, null, map, getMutation);
 }
 
 /**
@@ -128,5 +128,5 @@ export function useActions<TActions = any>(storeOrMap: Store<any> | KnownKeys<TA
 		map = store as KnownKeys<TActions>[];
 		store = getStoreFromInstance();
 	}
-	return useMapping(store, null, map, getAction);
+	return useMapping(store as Store<any>, null, map, getAction);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export * from './global'
-export * from './namespaced'
-export * from './wrapper'
+export * from './global';
+export * from './namespaced';
+export * from './wrapper';

--- a/src/namespaced.ts
+++ b/src/namespaced.ts
@@ -4,11 +4,39 @@ import {Store} from 'vuex';
 
 export type Nullish = null | undefined;
 
-function computedState(store: any, namespace: string, prop: string) {
-	let module = namespace.split('/').reduce((module, key) => module[key], store.state) 
+/**
+ * Gets a computed observable fro the vuex state
+ * @param store The store to get the state from
+ * @param namespace The namespace to get the sate from
+ * @param prop The state prop to get
+ * @returns A computed observable from vuex state
+ */
+function computedState(store: Store<any>, namespace: string, prop: string) {
+	const module = namespace.split('/').reduce((module, key) => module[key], store.state)
 	return computed(() => module[prop])
 }
 
+/**
+ * Get the state of the module at the provided namespace.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param namespace The namespace to get this state from
+ * @param map An array of known State keys for this modules namespace
+ *
+ * @example
+ * const { foo, bar } = useNamespacedState('moduleNamespace', ['foo', 'bar']);
+ */
+export function useNamespacedState<TState = any>(namespace: string, map: KnownKeys<TState>[]): RefTypes<TState>
+/**
+ * Get the state of the module at the provided namespace, from the provided store.
+ * @param store An instance of the vuex store to get the state from
+ * @param namespace The namespace to get this state from
+ * @param keys An array of known State keys for this modules namespace
+ *
+ * @example
+ * const { foo, bar } = useNamespacedState(store, 'moduleNamespace', ['foo', 'bar']);
+ */
+export function useNamespacedState<TState = any>(store: Store<any> | Nullish, namespace: string, map: KnownKeys<TState>[]): RefTypes<TState>
 export function useNamespacedState<TState = any>(storeOrNamespace: Store<any> | string  | Nullish, namespaceOrMap: string | KnownKeys<TState>[], map?: KnownKeys<TState>[]): RefTypes<TState> {
 	let store: Store<any>, namespace: string;
 
@@ -23,6 +51,27 @@ export function useNamespacedState<TState = any>(storeOrNamespace: Store<any> | 
 	return useMapping(store, namespace, map, computedState);
 }
 
+/**
+ * Retrieves mutations from of the module at the provided namespace.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param namespace The namespace to get mutations from
+ * @param map An array of known mutation keys from this modules namespace
+ *
+ * @example
+ * const { setFoo, setBar } = useNamespacedMutations('moduleNamespace', ['setFoo', 'setBar']);
+ */
+export function useNamespacedMutations<TMutations = any>(namespace: string, map: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function>
+/**
+ * Retrieves mutations from of the module at the provided namespace, from the provided store.
+ * @param store An instance of the vuex store to get mutations from
+ * @param namespace The namespace to get mutations from
+ * @param keys An array of known mutation keys from this modules namespace
+ *
+ * @example
+ * const { setFoo, setBar } = useNamespacedMutations(store, 'moduleNamespace', ['setFoo', 'setBar']);
+ */
+export function useNamespacedMutations<TMutations = any>(store: Store<any> | Nullish, namespace: string, map: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function>
 export function useNamespacedMutations<TMutations = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TMutations>[], map?: KnownKeys<TMutations>[]): ExtractTypes<TMutations, Function> {
 	let store: Store<any>, namespace: string;
 
@@ -37,6 +86,27 @@ export function useNamespacedMutations<TMutations = any>(storeOrNamespace: Store
 	return useMapping(store, namespace, map, getMutation);
 }
 
+/**
+ * Retrieves actions from the module at the provided namespace.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param namespace The namespace to get actions from
+ * @param map An array of known action keys for this modules namespace
+ *
+ * @example
+ * const { doFoo, doBar } = useNamespacedActions('moduleNamespace', ['doFoo', 'doBar']);
+ */
+export function useNamespacedActions<TActions = any>(namespace: string, map:  KnownKeys<TActions>[]): ExtractTypes<TActions, Function>
+/**
+ * Retrieves actions from the module at the provided namespace, from the provided store.
+ * @param store An instance of the vuex store to get actions from
+ * @param namespace The namespace to get actions from
+ * @param keys An array of known action keys for this modules namespace
+ *
+ * @example
+ * const { doFoo, doBar } = useNamespacedActions(store, 'moduleNamespace', ['doFoo', 'doBar']);
+ */
+export function useNamespacedActions<TActions = any>(store: Store<any> | Nullish, namespace: string, map: KnownKeys<TActions>[]): ExtractTypes<TActions, Function>
 export function useNamespacedActions<TActions = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TActions>[], map?: KnownKeys<TActions>[]): ExtractTypes<TActions, Function> {
 	let store: Store<any>, namespace: string;
 
@@ -51,6 +121,27 @@ export function useNamespacedActions<TActions = any>(storeOrNamespace: Store<any
 	return useMapping(store, namespace, map, getAction);
 }
 
+/**
+ * Retrieves getters from the module at the provided namespace.
+ *
+ * Injects the vuex store from the root vue instance.
+ * @param namespace The namespace to retrieve getters from
+ * @param map An array of known getter keys for this modules namespace
+ *
+ * @example
+ * const { getFoo, getBar } = useNamespacedGetters('moduleNamespace', ['getFoo', 'getBar']);
+ */
+export function useNamespacedGetters<TGetters = any>(namespace: string, map: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters>
+/**
+ * Retrieves getters from the module at the provided namespace, from the provided store.
+ * @param store An instance of the vuex store to retrieve getters from
+ * @param namespace The namespace to retrieve getters from
+ * @param keys An array of known getter keys for this modules namespace
+ *
+ * @example
+ * const { getFoo, getBar } = useNamespacedGetters(store, 'moduleNamespace', ['getFoo', 'getBar']);
+ */
+export function useNamespacedGetters<TGetters = any>(store: Store<any> | Nullish, namespace: string , map: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters>
 export function useNamespacedGetters<TGetters = any>(storeOrNamespace: Store<any> | string | Nullish, namespaceOrMap: string | KnownKeys<TGetters>[], map?: KnownKeys<TGetters>[]): ExtractGetterTypes<TGetters> {
 	let store: Store<any>, namespace: string;
 
@@ -65,12 +156,33 @@ export function useNamespacedGetters<TGetters = any>(storeOrNamespace: Store<any
 	return useMapping(store, namespace, map, computedGetter);
 }
 
-export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(storeOrNamespace: Store<any> | string, namespace?: string):{
-	useState: (map?: KnownKeys<TState>[]) => RefTypes<TState>;
-	useGetters: (map?: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
-	useMutations: (map?: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
-	useActions: (map?: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
-} {
+export type NamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any> = {
+	useState: (map: KnownKeys<TState>[]) => RefTypes<TState>;
+	useGetters: (map: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
+	useMutations: (map: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
+	useActions: (map: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
+}
+
+/**
+ *
+ * @param namespace The namespace to create helpers for
+ *
+ * @example
+ * const { useState, useGetters, useMutations, useAction } = createNamespacedHelpers('foobar');
+ * const { foo, bar } = useState(['foo', 'bar']);
+ */
+export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(namespace: string): NamespacedHelpers<TState, TGetters, TActions, TMutations>
+/**
+ *
+ * @param store The store to create namespaced helpers for
+ * @param namespace The namespace to create helpers for
+ *
+ * @example
+ * const { useState, useGetters, useMutations, useAction } = createNamespacedHelpers(store, 'foobar');
+ * const { foo, bar } = useState(['foo', 'bar']);
+ */
+export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(store: Store<any>, namespace: string): NamespacedHelpers<TState, TGetters, TActions, TMutations>
+export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(storeOrNamespace: Store<any> | string, namespace?: string): NamespacedHelpers<TState, TGetters, TActions, TMutations> {
 	let store: Store<any> | Nullish = undefined;
 	if (arguments.length === 1) {
 		namespace = storeOrNamespace as string;
@@ -80,10 +192,11 @@ export function createNamespacedHelpers<TState = any, TGetters = any, TActions =
 			throw new Error('Namespace is missing to provide namespaced helpers')
 		}
 	}
+
 	return {
-		useState: (map?: KnownKeys<TState>[]) => useNamespacedState(store, namespace as string, map),
-		useGetters: (map?: KnownKeys<TGetters>[]) => useNamespacedGetters(store, namespace as string, map),
-		useMutations: (map?: KnownKeys<TMutations>[]) => useNamespacedMutations(store, namespace as string, map),
-		useActions: (map?: KnownKeys<TActions>[]) => useNamespacedActions(store, namespace as string, map),
+		useState: (map: KnownKeys<TState>[]) => useNamespacedState(store, namespace as string, map),
+		useGetters: (map: KnownKeys<TGetters>[]) => useNamespacedGetters(store, namespace as string, map),
+		useMutations: (map: KnownKeys<TMutations>[]) => useNamespacedMutations(store, namespace as string, map),
+		useActions: (map: KnownKeys<TActions>[]) => useNamespacedActions(store, namespace as string, map),
 	}
 }

--- a/src/namespaced.ts
+++ b/src/namespaced.ts
@@ -1,11 +1,11 @@
 import {computed} from '@vue/composition-api';
+import {Store} from 'vuex/types';
 import {computedGetter, getAction, getMutation, getStoreFromInstance, useMapping, KnownKeys, RefTypes, ExtractTypes, ExtractGetterTypes} from './util';
-import {Store} from 'vuex';
 
 export type Nullish = null | undefined;
 
 /**
- * Gets a computed observable fro the vuex state
+ * Gets a computed observable for the vuex state.
  * @param store The store to get the state from
  * @param namespace The namespace to get the sate from
  * @param prop The state prop to get
@@ -156,15 +156,22 @@ export function useNamespacedGetters<TGetters = any>(storeOrNamespace: Store<any
 	return useMapping(store, namespace, map, computedGetter);
 }
 
+export type NamespacedUseState<TState> = (map: KnownKeys<TState>[]) => RefTypes<TState>;
+export type NamespacedUseGetter<TGetters> = (map: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
+export type NamespacedUseMutations<TMutations> = (map: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
+export type NamespacedUseActions<TActions> = (map: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
+
 export type NamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any> = {
-	useState: (map: KnownKeys<TState>[]) => RefTypes<TState>;
-	useGetters: (map: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
-	useMutations: (map: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
-	useActions: (map: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
+	useState: NamespacedUseState<TState>;
+	useGetters: NamespacedUseGetter<TGetters>;
+	useMutations: NamespacedUseMutations<TMutations>;
+	useActions: NamespacedUseActions<TActions>;
 }
 
 /**
+ * Creates namespaced helpers for a vuex module.
  *
+ * Injects the vuex store from the root vue instance.
  * @param namespace The namespace to create helpers for
  *
  * @example
@@ -173,7 +180,7 @@ export type NamespacedHelpers<TState = any, TGetters = any, TActions = any, TMut
  */
 export function createNamespacedHelpers<TState = any, TGetters = any, TActions = any, TMutations = any>(namespace: string): NamespacedHelpers<TState, TGetters, TActions, TMutations>
 /**
- *
+ * Creates namespaced helpers for a vuex module in the provided store.
  * @param store The store to create namespaced helpers for
  * @param namespace The namespace to create helpers for
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,7 +27,7 @@ export declare type ExtractGetterTypes<O> = {
 
 export declare type KnownKeys<T> = {
 	[K in keyof T]: string extends K
-		? (T extends any ? any : never)
+		? (T extends any ? string : never)
 		: number extends K
 			? never
 			: K

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,4 +1,5 @@
 import {computed, getCurrentInstance, Ref} from '@vue/composition-api';
+import {Store} from 'vuex/types';
 
 declare type OmitFirstArg<F, TReturn> =
 	F extends (x: any, ...args: infer P) => any
@@ -41,7 +42,7 @@ export declare type RefTypes<T> = {
 	readonly [Key in keyof T]: Ref<T[Key]>
 }
 
-function runCB<T>(cb: Function, store: any, namespace: string | null, prop: KnownKeys<T> | string) {
+function runCB<T>(cb: Function, store: Store<any>, namespace: string | null, prop: KnownKeys<T> | string) {
 	if (cb.length === 3) { // choose which signature to pass to cb function
 		return cb(store, namespace, prop);
 	} else {
@@ -49,14 +50,14 @@ function runCB<T>(cb: Function, store: any, namespace: string | null, prop: Know
 	}
 }
 
-function useFromArray(store: any, namespace: string | null, props: Array<string>, cb: Function) {
+function useFromArray(store: Store<any>, namespace: string | null, props: Array<string>, cb: Function) {
 	return props.reduce((result, prop) => {
 		result[prop] = runCB(cb, store, namespace, prop)
 		return result;
 	}, {} as any);
 }
 
-function useFromObject<T>(store: any, namespace: string | null, props: KnownKeys<T>[], cb: Function) {
+function useFromObject<T>(store: Store<any>, namespace: string | null, props: KnownKeys<T>[], cb: Function) {
 	const obj: any = {};
 	for (let key in props) {
 		if (props.hasOwnProperty(key)) {
@@ -66,7 +67,7 @@ function useFromObject<T>(store: any, namespace: string | null, props: KnownKeys
 	return obj;
 }
 
-export function computedGetter<T = any>(store: any, prop: string) {
+export function computedGetter<T = any>(store: Store<any>, prop: string) {
 	return computed<T>(() => store.getters[prop]);
 }
 
@@ -82,7 +83,7 @@ export function getAction(store: any, action: string): Function {
 	}
 }
 
-export function useMapping<T>(store: any, namespace: string | null, map: KnownKeys<T>[] | Array<string> | undefined, cb: Function) {
+export function useMapping<T>(store: Store<any>, namespace: string | null, map: KnownKeys<T>[] | undefined, cb: Function) {
 	if (!map) {
 		return {};
 	}

--- a/src/wrapper.ts
+++ b/src/wrapper.ts
@@ -1,12 +1,22 @@
-import {createNamespacedHelpers} from './namespaced';
-import {useActions, useGetters, useMutations, useState} from './global'
+import {Store} from "vuex/types";
+import {createNamespacedHelpers, NamespacedHelpers} from "./namespaced";
+import {useActions, useGetters, useMutations, useState} from "./global";
+import {KnownKeys, RefTypes, ExtractGetterTypes, ExtractTypes} from "./util";
 
-export function wrapStore(store: any) {
-	return {
-		createNamespacedHelpers: createNamespacedHelpers.bind(null, store),
-		useActions: useActions.bind(null, store),
-		useGetters: useGetters.bind(null, store),
-		useMutations: useMutations.bind(null, store),
-		useState: useState.bind(null, store)
-	}
+export type WrappedStore = {
+    createNamespacedHelpers: <TState = any, TGetters = any, TActions = any, TMutations = any>(namespace: string) => NamespacedHelpers<TState, TGetters, TActions, TMutations>;
+    useState: <TState = any>(map: KnownKeys<TState>[]) => RefTypes<TState>;
+	useGetters: <TGetters = any>(map: KnownKeys<TGetters>[]) => ExtractGetterTypes<TGetters>;
+	useMutations: <TMutations = any>(map: KnownKeys<TMutations>[]) => ExtractTypes<TMutations, Function>;
+	useActions: <TActions = any>(map: KnownKeys<TActions>[]) => ExtractTypes<TActions, Function>;
+};
+
+export function wrapStore(store: Store<any>): WrappedStore {
+    return {
+        createNamespacedHelpers: createNamespacedHelpers.bind(null, store),
+        useActions: useActions.bind(null, store),
+        useGetters: useGetters.bind(null, store),
+        useMutations: useMutations.bind(null, store),
+        useState: useState.bind(null, store),
+    };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
 	"module": "esnext",
 	"strict": true,
 	"esModuleInterop": true,
+    "strictBindCallApply": false,
 	"forceConsistentCasingInFileNames": true,
 	"declaration": true,
 	"declarationDir": "dist/types",


### PR DESCRIPTION
added function overloads to give function variants more documentation.
made map types bottom out to string rather than any.
made map non optional for namespaced helpers to remove confusion.
add store type to all utils that take store.
turned off strict bind  due to a typing error that is only triggered by typescript 3 (works in typescript 4.2).
added types to wrapStore.