### PR TITLE
Fix vue-cli transpile config

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ When using `vue-cli`, use this instead
 module.exports = {
   ...
   chainWebpack: config => {
-    config
+    config.module
       .rule('ts')
-      .include
-      .add(/vuex-composition-helpers/)
+      .exclude
+      .add(/node_modules\/vuex-composition-helpers/)
   }
 }
 ```


### PR DESCRIPTION
I believe there's an error in current `vue-cli` transpile config. It doesn't work as it is (at least not for me), and taking in consideration what's suggested for `webpack` right above, I think it should be `exclude` instead of `include`.