### PR TITLE
Fix compatibility with TypeScript 4.7.x

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -29,7 +29,7 @@ export declare type ExtractGetterTypes<O> = {
 	readonly [K in keyof O]: Ref<InferGetterType<O[K]>>;
 };
 
-export declare type KnownKeys<T> = {
+declare type KnownKeysWithAllPrimitiveTypes<T> = {
 	[K in keyof T]: string extends K
 		? (T extends any ? any : never)
 		: number extends K
@@ -40,6 +40,8 @@ export declare type KnownKeys<T> = {
 	}
 	? U
 	: never;
+
+export declare type KnownKeys<T> = Exclude<KnownKeysWithAllPrimitiveTypes<T>, symbol>
 
 export declare type RefTypes<T> = {
 	readonly [Key in keyof T]: Ref<T[Key]>


### PR DESCRIPTION
TypeScript 4.7.x complains about the possible implicit conversion from `symbol` to `string`. Doing the conversion explicitly fixes the issues.

To reproduce the issue, you can upgrade the TypeScript version set as a dev dependency and then run the test suite. You will see error like this without this contribution:

```
 FAIL  tests/global-state.test.ts
  ● Test suite failed to run
    src/util.ts:52:48 - error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
    52   return cb(store, namespace ? `${namespace}/${prop}` : prop);
```