### PR TITLE
[Next branch] Fix compatibility with TypeScript 4.7.x

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -46,7 +46,7 @@ function runCB<T>(cb: Function, store: any, namespace: string | null, prop: Know
 	if (cb.length === 3) { // choose which signature to pass to cb function
 		return cb(store, namespace, prop);
 	} else {
-		return cb(store, namespace ? `${namespace}/${prop}` : prop);
+		return cb(store, namespace ? `${namespace}/${String(prop)}` : prop);
 	}
 }
 


### PR DESCRIPTION
This change is similar to #68 but it targets the `next` branch.

TypeScript 4.7.x complains about the possible implicit conversion from `symbol` to `string`. Doing the conversion explicitly fixes the issues.

To reproduce the issue, you can upgrade the TypeScript version set as a dev dependency and then run the test suite. You will see error like this without this contribution:

```
 FAIL  tests/global-state.test.ts
  ● Test suite failed to run
    src/util.ts:49:48 - error TS2731: Implicit conversion of a 'symbol' to a 'string' will fail at runtime. Consider wrapping this expression in 'String(...)'.
    49   return cb(store, namespace ? `${namespace}/${prop}` : prop);
```