### PR TITLE
[Next branch] Fix compatibility with TypeScript 4.7.x

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -26,7 +26,7 @@ export declare type ExtractGetterTypes<O> = {
 	readonly [K in keyof O]: ComputedRef<DeepReadonly<InferGetterType<O[K]>>>
 };
 
-export declare type KnownKeys<T> = {
+export declare type KnownKeysWithAllPrimitiveTypes<T> = {
 	[K in keyof T]: string extends K
 		? (T extends any ? any : never)
 		: number extends K
@@ -37,6 +37,8 @@ export declare type KnownKeys<T> = {
 	}
 	? U
 	: never;
+
+export declare type KnownKeys<T> = Exclude<KnownKeysWithAllPrimitiveTypes<T>, symbol>
 
 export declare type ComputedRefTypes<T> = {
 	readonly [Key in keyof T]: ComputedRef<DeepReadonly<T[Key]>>


### PR DESCRIPTION
TypeScript 4.7.x complains about the possible implicit conversion from
`symbol` to `string`. In order to resolve the issue we do not consider
known keys that are symbols as a possibility. Vuex cannot use them since
they cannot be serialized.

To reproduce the issue, you can upgrade the TypeScript version set as a
dev dependency and then run the test suite.

(cherry picked from commit 0670f3adf21da759edfc3269c5eab4888917c2e2 see #68)